### PR TITLE
chore/github-actions: bump go version to v1.22 and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: make build
 
     - name: Execute unit-test
-      run: make test-unit
+      run: make test
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: ^1.20
+        go-version: ^1.22
 
     - name: Check out code
       uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,6 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
-test-unit: ## Run unit tests.
-	go test ./internal/... -coverprofile cover.out
-
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:


### PR DESCRIPTION
**What type of PR is this?**
> /kind chore

**What does this PR do / why we need it**:
This PR bumps go version to 1.22 and fixes the CI pipeline.

**Which issue(s) this PR fixes**:

Fixes #16 

**How to test changes / Special notes to the reviewer**:
